### PR TITLE
allowing role_manager, authorizer, authenticator to override on docker runtime.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -125,6 +125,9 @@ if [ "$1" = 'cassandra' ]; then
         num_tokens \
         rpc_address \
         start_rpc \
+        authenticator \
+        authorizer \
+        role_manager \
     ; do
         var="CASSANDRA_${yaml^^}"
         val="${!var}"


### PR DESCRIPTION
Hi Team, 

allowing role_manager, authorizer, authenticator to override on docker runtime which is easy to modify PasswordAuthenticator , so that any super admin user can be created.